### PR TITLE
EthernetIndustruino: Fix memory leak

### DIFF
--- a/EthernetIndustruino/EthernetIndustruino.cpp
+++ b/EthernetIndustruino/EthernetIndustruino.cpp
@@ -14,8 +14,9 @@ uint16_t EthernetClass::_server_port[MAX_SOCK_NUM] = { 0, };
 #if defined(WIZ550io_WITH_MACADDRESS)
 int EthernetClass::begin(uint8_t *mac_address)
 {
-    _dhcp = new DhcpClass();
-    
+    static DhcpClass s_dhcp;
+    _dhcp = &s_dhcp;
+
     // Initialise the basic info
     W5100.init();
     W5100.setMACAddress(mac_address);


### PR DESCRIPTION
## Applies to

Industruino IND.I/O (AT90USB1286) used with the Ethernet expansion module.

## Bug Description

In an actual application of us, I occasionally found some Industruinos of ours to have stopped working. They completely hanged.
Thanks to a verbose (rather silly) log output, I could quickly narrow it down to happen only when trying to (re-)establish network connectivity using DHCP.

### Example Code

I prepared the following simple Sketch to show, what's happening:

```C
/* Rather simplified and stripped down WebClient example of the EthernetIndustruino lib. */
#include <SPI.h>
#include <EthernetIndustruino.h>

byte mac[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED};

EthernetClient client;

void setup() {
  Serial.begin(9600);
  while (!Serial) { ; }
}

void loop() {
  Serial.print("Free RAM in Bytes, before Ethernet.begin .: ");
  Serial.println(freeRam(), DEC);

  if (Ethernet.begin(mac) == 0) {
    // Output is irrelevant
    // Serial.println("Failed to configure Ethernet using DHCP");
  } else {
    // Output is irrelevant
    // Serial.println("Ethernet configured using DHCP");
  }

  Serial.print("Free RAM in Bytes, after Ethernet.begin ..: ");
  Serial.println(freeRam(), DEC);

  delay(1000);

  Serial.println("Repeating ...");
}

/* Simplified version of the officially recommended library to detect available memory.
 * Taken from: http://playground.arduino.cc/code/AvailableMemory */
int freeRam() {
  extern unsigned int __heap_start;
  extern void* __brkval;
  int free_memory;

  return ( int ) &free_memory - ( __brkval == 0 ? ( int ) &__heap_start : ( int ) __brkval );
}
```

### Example Output

In the Serial Monitor's output, I quickly realised, that the `begin` method eats up 100 Bytes of RAM on every invokation:

```
Free RAM in Bytes, before Ethernet.begin .: 7767
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7567
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7567
Free RAM in Bytes, after Ethernet.begin ..: 7467
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7467
Free RAM in Bytes, after Ethernet.begin ..: 7367
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7367
Free RAM in Bytes, after Ethernet.begin ..: 7267
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7267
Free RAM in Bytes, after Ethernet.begin ..: 7167
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7167
Free RAM in Bytes, after Ethernet.begin ..: 7067
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7067
Free RAM in Bytes, after Ethernet.begin ..: 6967
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 6967
Free RAM in Bytes, after Ethernet.begin ..: 6867
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 6867
Free RAM in Bytes, after Ethernet.begin ..: 6767
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 6767
Free RAM in Bytes, after Ethernet.begin ..: 6667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 6667
Free RAM in Bytes, after Ethernet.begin ..: 6567
```

## Proposed Solution

This PR's proposed changes reflect the particular code's current state, as found in the current version of Arduino's "original" Ethernet library.

**Example Output, after patching:**

A `DhcpClass` instance gets only created once, no more than 100 Bytes for a single time are allocated.

```
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
Repeating ...
Free RAM in Bytes, before Ethernet.begin .: 7667
Free RAM in Bytes, after Ethernet.begin ..: 7667
```
