### PR TITLE
Fix analogWrite in `mA_p` mode

### DIFF
--- a/Indio/Indio.cpp
+++ b/Indio/Indio.cpp
@@ -254,7 +254,7 @@ float IndioClass::analogRead(int pin)
 	  }
       if(mode_DAC[pin]==4)
       {
-          output = map(((value+4)*100), DAC_current_low_uA[pin], DAC_current_high_uA[pin], DAC_current_low_raw[pin], DAC_current_high_raw[pin]);
+          output = map((4+(value*0.16))*1000, DAC_current_low_uA[pin], DAC_current_high_uA[pin], DAC_current_low_raw[pin], DAC_current_high_raw[pin]);
       }
       if(mode_DAC[pin]==5)
       {


### PR DESCRIPTION
This fixes the calculation of the `output` value to be written during `analogWrite` if the channel is set to `mA_p` mode.

The calculation now used (`output = (4 + ([percentage] * 0.16)) * 1000`) returns valid results according to the raw values written for `mA` and `mA_raw` modes (between `4.000` and `20.000`).