### PR TITLE
Fix analogRead in `mA_p` mode

### DIFF
--- a/Indio/Indio.cpp
+++ b/Indio/Indio.cpp
@@ -167,7 +167,7 @@ float IndioClass::analogRead(int pin)
 	if (mode_ADC[pin]==4)
 	{
 	current=map(((data/mvDivisor)+2048), ADC_current_low_raw[pin], ADC_current_high_raw[pin], ADC_current_low_uA[pin], ADC_current_high_uA[pin]);
-	return ((((current-4000)/20000))*100);
+	return ((((current-4000)/16000))*100);
 	}
 	if (mode_ADC[pin]==5)
 	{


### PR DESCRIPTION
This PR fixes `analogRead`'s return value for channels set to `mA_p` mode.

**Old calculation**

```
returnValue = ( ( current - 4000 ) / 20000 ) * 100
```

Which yields the following results for the specified currents:

| 0mA | 4mA | 8mA | 16mA | 20mA |
| - | - | - | - | - |
| -20% | 0% | 20% | 60% | 80% |

**The new calculation** correctly reduces the divisor by the range's offset of 4mA:

```
returnValue = ( ( current - 4000 ) / 16000 ) * 100
```

Which yields the following results for the specified currents:

| 0mA | 4mA | 8mA | 16mA | 20mA |
| - | - | - | - | - |
| -25% | 0% | 25% | 75% | 100% |
