### PR TITLE
Fix switching analog read modes

### DIFF
--- a/Indio/Indio.cpp
+++ b/Indio/Indio.cpp
@@ -310,7 +310,8 @@ float IndioClass::analogRead(int pin)
 	void IndioClass::analogReadMode(int pin, int mode)
 	{
         int res=(INDIO_ADC_RESOLUTION-12)/2;
-        
+        int modeSwitchPin;
+
         switch (res) {
             case 0:
                 sample_rate = 5;
@@ -329,8 +330,22 @@ float IndioClass::analogRead(int pin)
                  mvDivisor = 64;
                 break;
         }
-       
- 
+
+        switch (pin) {
+            case 1:
+                modeSwitchPin = 11;
+                break;
+            case 2:
+                modeSwitchPin = 10;
+                break;
+            case 3:
+                modeSwitchPin = 13;
+                break;
+            case 4:
+                modeSwitchPin = 12;
+                break;
+        }
+
         previouspin = 0;
         
         this->setAddress2(0x20);
@@ -344,50 +359,50 @@ float IndioClass::analogRead(int pin)
 	 // setup the mode of a pin from PCA9555 call flushMode() or flush() to send it on PCA9555
       if(mode == 1)
       {
-	    
-        bitWrite(outputBuffer2, pin+9, HIGH);
+
+        bitWrite(outputBuffer2, modeSwitchPin, HIGH);
 		adcConfig[pin]= MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2;
 		mode_ADC[pin]=1;
       }
       else if (mode == 2)
       {
-         bitWrite(outputBuffer2, pin+9, LOW);
+         bitWrite(outputBuffer2, modeSwitchPin, LOW);
          adcConfig[pin] = MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2;
 		 mode_ADC[pin]=2;
       }
 	  else if (mode == 3)
 	  {
-	     bitWrite(outputBuffer2, pin+9, LOW);
+	     bitWrite(outputBuffer2, modeSwitchPin, LOW);
          adcConfig[pin] = MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2 | 1;
 		 mode_ADC[pin]=3;
 	  }
 	  else if (mode == 4)
 	  {
-	     bitWrite(outputBuffer2, pin+9, HIGH);
+	     bitWrite(outputBuffer2, modeSwitchPin, HIGH);
          adcConfig[pin]= MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2;
 		 mode_ADC[pin]=4;
 	  }
 	  else if (mode == 5)
       {
-         bitWrite(outputBuffer2, pin+9, LOW);
+         bitWrite(outputBuffer2, modeSwitchPin, LOW);
          adcConfig[pin] = MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2;
 		 mode_ADC[pin]=5;
       }
 	  else if (mode == 6)
 	  {
-	     bitWrite(outputBuffer2, pin+9, LOW);
+	     bitWrite(outputBuffer2, modeSwitchPin, LOW);
          adcConfig[pin] = MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2 | 1;
 		 mode_ADC[pin]=6;
 	  }
 	  else if (mode == 7)
 	  {
-	     bitWrite(outputBuffer2, pin+9, HIGH);
+	     bitWrite(outputBuffer2, modeSwitchPin, HIGH);
          adcConfig[pin] = MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2;
 		 mode_ADC[pin]=7;
 	  }
       else if (mode == 8)
 	  {
-          bitWrite(outputBuffer2, pin+9, LOW);
+          bitWrite(outputBuffer2, modeSwitchPin, LOW);
           adcConfig[pin] = MCP342X_START | MCP342X_CONTINUOUS | (pin-1) << 5 | res<< 2;
           mode_ADC[pin]=8;
 	  }


### PR DESCRIPTION
Pin definitions for the switching the analog input channels' reading modes were defined incorrectly, preventing some combinations of reading currents and voltages to not function properly.  
(Setting _all_ channels to either read currents _or_ voltages worked fine, setting channels in groups (ch. 1 _and_ 2 and/or ch. 3 _and_ 4) did work, too — other combinations did not yield proper current readings).

In fact, according to Loic, the pins assigned to switching the channels' modes were twisted and should instead read `CH 1 => pin 11`, `CH 2 => pin 10`, `CH 3 => pin 13` and `CH 4 => pin 12`.

This PR introduces the proposed changes.  
Tested on multiple IND.I/O baseboards with 1286 topboard.